### PR TITLE
fix: incorrect email address encoding

### DIFF
--- a/email_test.go
+++ b/email_test.go
@@ -19,7 +19,7 @@ import (
 func prepareEmail() Email {
 	e := Email{}
 	e.From = "Jordan Wright <test@example.com>"
-	e.To = []string{"test@example.com"}
+	e.To = []string{"Bécassine <test@example.com>"}
 	e.Bcc = []string{"test_bcc@example.com"}
 	e.Cc = []string{"test_cc@example.com"}
 	e.Subject = "Awesome Subject"
@@ -37,16 +37,31 @@ func basicTests(t *testing.T, e Email) *mail.Message {
 		t.Fatal("Could not parse rendered message: ", err)
 	}
 
+	toAddr := mail.Address{
+		Name:    "Bécassine",
+		Address: "test@example.com",
+	}
+
+	fromAddr := mail.Address{
+		Name:    "Jordan Wright",
+		Address: "test@example.com",
+	}
+
+	ccAddr := mail.Address{
+		Name:    "",
+		Address: "test_cc@example.com",
+	}
+
 	expectedHeaders := map[string]string{
-		"To":      "test@example.com",
-		"From":    "Jordan Wright <test@example.com>",
-		"Cc":      "test_cc@example.com",
+		"To":      toAddr.String(),
+		"From":    fromAddr.String(),
+		"Cc":      ccAddr.String(),
 		"Subject": "Awesome Subject",
 	}
 
 	for header, expected := range expectedHeaders {
 		if val := msg.Header.Get(header); val != expected {
-			t.Errorf("Wrong value for message header %s: %v != %v", header, expected, val)
+			t.Errorf("Wrong value for message header %s: %v != %v", header, val, expected)
 		}
 	}
 	return msg


### PR DESCRIPTION
As discusses in [this issue](https://github.com/knadh/listmonk/issues/34#issuecomment-703109584), the email addressess were not being encoded according to RFC 2047.
Here we parse plain text email addresses to `mail.Address` and then format it again with `mail.Address.String()` which handles various edge cases with email address encoding.