### PR TITLE
Fix parsing attachments in NewEmailFromReader.

### DIFF
--- a/email.go
+++ b/email.go
@@ -222,6 +222,18 @@ func NewEmailFromReader(r io.Reader) (Email, error) {
 			e.Text = p.body
 		case ct == ContentTypeHTML:
 			e.HTML = p.body
+		default:
+			// Get filename for the attachment from the content disposition header.
+			_, params, err := mime.ParseMediaType(p.header.Get(HdrContentDisposition))
+			if err != nil {
+				continue
+			}
+			attachment := Attachment{
+				Filename: params["filename"],
+				Content:  p.body,
+				Header:   p.header,
+			}
+			e.Attachments = append(e.Attachments, attachment)
 		}
 	}
 	return e, nil


### PR DESCRIPTION
Currently `NewEmailFromReader` does parse attachments from the reader but doesn't populate the `Attachments` field in the returned email. This fixes that.