### PR TITLE
Use parseSender() to extract sender address

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -363,14 +363,14 @@ func (c *conn) send(e Email) (bool, error) {
 		return false, err
 	}
 
-	// Extract the e-mail from the address.
-	from, err := mail.ParseAddress(e.From)
+	// Extract SMTP envelope sender from the email struct.
+	from, err := e.parseSender()
 	if err != nil {
 		return false, err
 	}
 
 	// Send the Mail command.
-	if err = c.conn.Mail(from.Address); err != nil {
+	if err = c.conn.Mail(from); err != nil {
 		return true, err
 	}
 


### PR DESCRIPTION
This changes the extraction of the `SMTP envelope from` to use the `parseSender()` function of the `Email` struct in `email.go`.

This honors a `Sender` if it is set in the struct.

Related to https://github.com/knadh/listmonk/issues/908