### PR TITLE
send RSET command on connection return

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -273,6 +273,10 @@ func (p *Pool) returnConn(c *conn, lastErr error) (err error) {
 		}
 	}
 
+	if err := c.conn.Reset(); err != nil {
+		return err
+	}
+
 	select {
 	case p.conns <- c:
 		return nil


### PR DESCRIPTION
I've been getting an error `503 5.5.1 Error: nested MAIL command ` once in a while. Couldn't reproduce the issue in local enviroment but i suspect that connections somehow are returned to pool in unfinished state and then used for sending next message resulting in multiple MAIL commands. Resetting connection when returning to pool solved the issue.