### PR TITLE
Reduce the p.createdConns when failed to create new connection

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -236,7 +236,13 @@ func (p *Pool) borrowConn() (*conn, error) {
 	case p.createdConns <= p.opt.MaxConns && len(p.conns) == 0:
 		p.createdConns++
 		p.mut.Unlock()
-		return p.newConn()
+		c, err := p.newConn()
+		if err != nil {
+			p.mut.Lock()
+			p.createdConns--
+			p.mut.Unlock()
+		}
+		return c, err
 	default:
 		p.mut.Unlock()
 	}


### PR DESCRIPTION
The number of created connections was not being decreased when `p.newConn()` returned an error. As a result, `p.createdConns` could reach the maximum allowed connections, causing new connections not to be created. This issue resulted in `borrowConn()` always returning `timed out waiting for free conn in pool` because there were no available connections in the pool and no new connections could be created since `p.createdConns` was already at the maximum.