### PR TITLE
Discard pooled SMTP connections on terminal SMTP errors

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -297,13 +297,13 @@ func (p *Pool) returnConn(c *conn, lastErr error) (err error) {
 	if lastErr != nil {
 		// Any error, except for textproto.Error (according to jordan-wright/email),
 		// is a bad connection that should be killed.
-	if isTerminalConnErr(lastErr) {
-		return lastErr
+		if isTerminalConnErr(lastErr) {
+			return lastErr
+		}
+		if _, ok := lastErr.(*textproto.Error); !ok {
+			return lastErr
+		}
 	}
-	if _, ok := lastErr.(*textproto.Error); !ok {
-		return lastErr
-	}
-}
 
 
 	// Always RSET (SMTP) the connection bfeore reusing it as some servers
@@ -503,6 +503,9 @@ func canRetry(err error) bool {
 	return false
 }
 
+// isTerminalConnErr reports whether the SMTP connection is no longer usable
+// and must be discarded. This is independent of whether the message itself
+// is retryable.
 func isTerminalConnErr(err error) bool {
 	if err == nil {
 		return false

--- a/pool.go
+++ b/pool.go
@@ -297,10 +297,14 @@ func (p *Pool) returnConn(c *conn, lastErr error) (err error) {
 	if lastErr != nil {
 		// Any error, except for textproto.Error (according to jordan-wright/email),
 		// is a bad connection that should be killed.
-		if _, ok := lastErr.(*textproto.Error); !ok {
-			return lastErr
-		}
+	if isTerminalConnErr(lastErr) {
+		return lastErr
 	}
+	if _, ok := lastErr.(*textproto.Error); !ok {
+		return lastErr
+	}
+}
+
 
 	// Always RSET (SMTP) the connection bfeore reusing it as some servers
 	// throw "sender already specified", or "commands out of sequence" errors.
@@ -493,6 +497,30 @@ func canRetry(err error) bool {
 	} else if _, ok := err.(*net.OpError); ok {
 		return true
 	} else if err == io.EOF {
+		return true
+	}
+
+	return false
+}
+
+func isTerminalConnErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// RFC 5321: 421 = Service not available, closing transmission channel
+	var tpErr *textproto.Error
+	if errors.As(err, &tpErr) && tpErr.Code == 421 {
+		return true
+	}
+
+	// Connection-level failures
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
 		return true
 	}
 


### PR DESCRIPTION
Some SMTP servers close a session after policy limits (e.g. time or message count) and return 421 Service not available, closing transmission channel, or close the connection mid-DATA.

In these cases the SMTP connection is no longer usable and must not be returned to the pool.

This change improves RFC-5321 compliance by treating 421 and connection-level errors as terminal, ensuring dead connections are discarded and retried on fresh connections.

This PR was created with ChatGPT and closes: https://github.com/knadh/smtppool/issues/18